### PR TITLE
use rsync -t so it won't do full sync everytime

### DIFF
--- a/bin/swarm
+++ b/bin/swarm
@@ -184,13 +184,13 @@ def cleanup(_args):
 
 def upload(server):
     # upload test plan and any other files in the current directory (dont upload locust.conf because it might contain master-only settings like run-time)
-    check_output(f"rsync -qr --exclude locust.conf --exclude *.png --exclude __pycache__ * {server}:")
+    check_output(f"rsync -qrt --exclude locust.conf --exclude *.png --exclude __pycache__ * {server}:")
     # upload locust-plugins
-    check_output(f"rsync -qr --exclude __pycache__ {locust_plugins.__path__[0]} {server}:")
+    check_output(f"rsync -qrt --exclude __pycache__ {locust_plugins.__path__[0]} {server}:")
     # Use this to upload locust
     # check_output(f"rsync -qr --exclude __pycache__ {locust.__path__[0]}/.. {server}:locust/")
     try:
-        check_output(f"rsync -qr --exclude __pycache__ {svs_locust.__path__[0]} {server}:")
+        check_output(f"rsync -qrt --exclude __pycache__ {svs_locust.__path__[0]} {server}:")
     except NameError:
         pass
     logging.debug(f"upload complete for {server}")


### PR DESCRIPTION
with -t rsync will preserve modification times so subsequence sync will be faster. It will be helpful if your test cases have a data file that is very large.